### PR TITLE
feat(lualine): show word and char counts

### DIFF
--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -10,6 +10,14 @@ return {
                         path = 1,
                     },
                 },
+                lualine_x = {
+                    function()
+                        local wc = vim.fn.wordcount()
+                        local words = wc.visual_words or wc.words
+                        local chars = wc.visual_chars or wc.chars
+                        return string.format("%dW %dC", words or 0, chars or 0)
+                    end,
+                },
             },
         },
         requires = { 'nvim-tree/nvim-web-devicons', opt = true }


### PR DESCRIPTION
## Summary
- show word and char counts in lualine statusline
- track counts from visual selections when present

## Testing
- `curl https://dikka.dev` *(error: CONNECT tunnel failed, response 403)*
- `nvim --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c269ab4a38832e8917666221e6499d